### PR TITLE
Implement Static Swap Page for Frontend #10

### DIFF
--- a/ui/Component/layout/Navigation.tsx
+++ b/ui/Component/layout/Navigation.tsx
@@ -1,0 +1,72 @@
+// components/layout/Navigation.tsx
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function Navigation() {
+  const pathname = usePathname();
+
+  const navItems = [
+    { name: "Home", path: "/" },
+    { name: "Swap", path: "/swap" },
+    { name: "Pools", path: "/pools" },
+    { name: "Dashboard", path: "/dashboard" },
+  ];
+
+  return (
+    <nav className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16">
+          <div className="flex">
+            <div className="flex-shrink-0 flex items-center">
+              {/* Logo */}
+              <Link href="/">
+                <span className="text-xl font-bold">DEX Name</span>
+              </Link>
+            </div>
+            <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
+              {navItems.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.path}
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    pathname === item.path
+                      ? "border-blue-500 text-gray-900 dark:text-white"
+                      : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-700"
+                  }`}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="hidden sm:ml-6 sm:flex sm:items-center">
+            <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg">
+              Connect Wallet
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile menu */}
+      <div className="sm:hidden">
+        <div className="pt-2 pb-3 space-y-1">
+          {navItems.map((item) => (
+            <Link
+              key={item.name}
+              href={item.path}
+              className={`block pl-3 pr-4 py-2 border-l-4 text-base font-medium ${
+                pathname === item.path
+                  ? "bg-blue-50 dark:bg-blue-900/20 border-blue-500 text-blue-700 dark:text-blue-300"
+                  : "border-transparent text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-700 hover:text-gray-800 dark:hover:text-gray-200"
+              }`}
+            >
+              {item.name}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/ui/Component/swap/SwapInterface.tsx
+++ b/ui/Component/swap/SwapInterface.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import TokenSelector from "./TokenSelector";
+import { ArrowDown } from "lucide-react";
+
+export default function SwapInterface() {
+  const [fromAmount, setFromAmount] = useState<string>("");
+  const [toAmount, setToAmount] = useState<string>("");
+  const [fromToken, setFromToken] = useState<string>("ETH");
+  const [toToken, setToToken] = useState<string>("USDC");
+
+  // Static price impact data
+  const priceImpact = "0.05%";
+  const minimumReceived = "0.00 USDC";
+  const slippageTolerance = "0.5%";
+
+  return (
+    <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
+      {/* From token section */}
+      <div className="mb-4 bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
+        <div className="flex justify-between mb-2">
+          <span className="text-gray-500 dark:text-gray-400">From</span>
+          <span className="text-gray-500 dark:text-gray-400">
+            Balance: 1.24 ETH
+          </span>
+        </div>
+        <div className="flex items-center">
+          <input
+            type="text"
+            value={fromAmount}
+            onChange={(e) => setFromAmount(e.target.value)}
+            placeholder="0.0"
+            className="w-full bg-transparent text-2xl outline-none"
+          />
+          <TokenSelector
+            selectedToken={fromToken}
+            onSelectToken={setFromToken}
+          />
+        </div>
+        <div className="flex justify-end mt-2">
+          <button className="text-blue-500 text-sm">MAX</button>
+        </div>
+      </div>
+
+      {/* Swap direction button */}
+      <div className="flex justify-center -my-2 relative z-0">
+        <button className="bg-blue-100 dark:bg-blue-900 p-2 rounded-full shadow-md hover:shadow-lg transition-all">
+          <ArrowDown className="h-5 w-5 text-blue-500 dark:text-blue-300" />
+        </button>
+      </div>
+
+      {/* To token section */}
+      <div className="mt-4 bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
+        <div className="flex justify-between mb-2">
+          <span className="text-gray-500 dark:text-gray-400">To</span>
+          <span className="text-gray-500 dark:text-gray-400">
+            Balance: 426.72 USDC
+          </span>
+        </div>
+        <div className="flex items-center">
+          <input
+            type="text"
+            value={toAmount}
+            onChange={(e) => setToAmount(e.target.value)}
+            placeholder="0.0"
+            className="w-full bg-transparent text-2xl outline-none"
+          />
+          <TokenSelector selectedToken={toToken} onSelectToken={setToToken} />
+        </div>
+      </div>
+
+      {/* Price info */}
+      <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-750 rounded-lg text-sm">
+        <div className="flex justify-between mb-1">
+          <span className="text-gray-500 dark:text-gray-400">Price</span>
+          <span>1 ETH = 2,734.21 USDC</span>
+        </div>
+        <div className="flex justify-between mb-1">
+          <span className="text-gray-500 dark:text-gray-400">Price Impact</span>
+          <span className="text-green-500">{priceImpact}</span>
+        </div>
+        <div className="flex justify-between mb-1">
+          <span className="text-gray-500 dark:text-gray-400">
+            Minimum received
+          </span>
+          <span>{minimumReceived}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-gray-500 dark:text-gray-400">
+            Slippage Tolerance
+          </span>
+          <span>{slippageTolerance}</span>
+        </div>
+      </div>
+
+      {/* Swap button */}
+      <button className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-lg mt-4 transition-colors">
+        Swap
+      </button>
+    </div>
+  );
+}

--- a/ui/Component/swap/TokenSelector.tsx
+++ b/ui/Component/swap/TokenSelector.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+interface TokenSelectorProps {
+  selectedToken: string;
+  onSelectToken: (token: string) => void;
+}
+
+const TOKEN_LIST = [
+  { symbol: "ETH", name: "Ethereum", logo: "🔷" },
+  { symbol: "USDC", name: "USD Coin", logo: "💲" },
+  { symbol: "WBTC", name: "Wrapped Bitcoin", logo: "🔶" },
+  { symbol: "STRK", name: "Starknet", logo: "⚡" },
+
+  { symbol: "ARB", name: "Arbitrum", logo: "🔷" },
+  { symbol: "LINK", name: "Chainlink", logo: "⛓️" },
+];
+
+export default function TokenSelector({
+  selectedToken,
+  onSelectToken,
+}: TokenSelectorProps) {
+  const [showTokenList, setShowTokenList] = useState(false);
+
+  const selectedTokenData =
+    TOKEN_LIST.find((token) => token.symbol === selectedToken) || TOKEN_LIST[0];
+
+  return (
+    <div className="relative">
+      <button
+        className="flex items-center space-x-1 bg-blue-100 dark:bg-blue-900 py-1 px-3 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-800"
+        onClick={() => setShowTokenList(!showTokenList)}
+      >
+        <span className="mr-1">{selectedTokenData.logo}</span>
+        <span>{selectedToken}</span>
+        <ChevronDown className="h-4 w-4" />
+      </button>
+
+      {showTokenList && (
+        <div className="absolute top-full mt-2 right-0 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg z-50 border border-gray-200 dark:border-gray-700">
+          <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+            <h3 className="font-medium">Select Token</h3>
+          </div>
+          <div className="max-h-60 overflow-y-auto">
+            {TOKEN_LIST.map((token) => (
+              <button
+                key={token.symbol}
+                className="flex items-center w-full p-3 hover:bg-gray-100 dark:hover:bg-gray-700 text-left"
+                onClick={() => {
+                  onSelectToken(token.symbol);
+                  setShowTokenList(false);
+                }}
+              >
+                <span className="mr-2 text-xl">{token.logo}</span>
+                <div>
+                  <div className="font-medium">{token.symbol}</div>
+                  <div className="text-sm text-gray-500 dark:text-gray-400">
+                    {token.name}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/app/swap/page.tsx
+++ b/ui/app/swap/page.tsx
@@ -1,0 +1,12 @@
+// app/swap/page.tsx
+
+import SwapInterface from "@/Component/swap/SwapInterface";
+
+export default function SwapPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4 sm:p-6 md:p-24">
+      <h1 className="text-3xl font-bold mb-8 text-center">Swap Tokens</h1>
+      <SwapInterface />
+    </main>
+  );
+}


### PR DESCRIPTION

## Overview
This PR implements a static swap page for the frontend as outlined in issue #10. The page provides a visual representation of the swap functionality inspired by popular DEX interfaces like Ekubo and Nostra.

## Changes
- Created a new `/swap` route using Next.js routing
- Implemented a responsive swap interface component with token selection
- Added token selection dropdown with popular tokens (ETH, USDC, WBTC, STRK, ARB, LINK)
- Integrated swap direction toggle
- Added price impact and transaction details section
- Included the swap page link in the navigation component

## Design Highlights
- Modern, clean interface similar to leading DEXs
- Responsive layout that works on both desktop and mobile
- Interactive elements (dropdowns, buttons) with proper hover states



## Screenshots
<img width="1280" alt="Screen Shot 2025-04-09 at 11 20 26 AM" src="https://github.com/user-attachments/assets/08ac2806-b89d-416a-8a66-4acf2f87eed8" />
<img width="1280" alt="Screen Shot 2025-04-09 at 11 20 33 AM" src="https://github.com/user-attachments/assets/d9b8f33e-71fb-41cc-952a-0350141fc40d" />

## Testing
- Verified the page renders correctly on different screen sizes
- Confirmed token selection dropdowns function properly
- Tested navigation to and from the swap page
- Verified both light and dark mode appearances



Closes #10