### PR TITLE
Feat: Auto Deployment of mdBook Github Pages on `main` branch push

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy mdBook to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+    contents: write  # To push a branch 
+    pages: write  # To push to a GitHub Pages site
+    id-token: write # To update the deployment status
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install mdBook
+        run: cargo install mdbook
+
+      - name: Build mdBook
+        run: |
+          cd docs
+          mdbook build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book
+          publish_branch: gh-pages


### PR DESCRIPTION
- Closes: #19 

I've created a GitHub Actions workflow file that will automate the deployment of mdBook to GitHub Pages. 

1. Trigger Configuration:
    - The workflow runs on pushes to the `main` branch
    - Also includes a `workflow_dispatch` trigger for manual runs
2. Permissions:
Set contents: write permission to allow the workflow to push to the gh-pages branch
3. Job Steps:
    - Checkout
    - Setup Rust: Installs the stable Rust toolchain with no additional component
    - Caching
    - Install mdBook
    - Build mdBook
    - Deploy: Uses `peaceiris/actions-gh-pages` to deploy the built site to the gh-pages branch

## Requirements:
- Ensure your repository has GitHub Pages enabled in the repository settings
- Configure GitHub Pages to use the `gh-pages` branch as the source

## Testing:
- Pushing a change to the `main branch` or
- Use the GitHub Actions UI to manually trigger the workflow
- Using the `act` tool locally fails due to absence of `GITHUB_TOKEN`

![image](https://github.com/user-attachments/assets/a6fb8b88-4e62-4472-9586-b3ecdd23e471)
